### PR TITLE
feat: Add precommit hooks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,14 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+set -e
+
+# just test
+cargo --locked nextest run --all-features
+cargo test --doc --all-features
+
+# just lint
+taplo format --check
+taplo lint
+cargo fmt --all --check
+cargo clippy --examples --tests --benches --all-features --all-targets --locked

--- a/.justfile
+++ b/.justfile
@@ -40,6 +40,9 @@ lints: toml-check-fmt toml-lint check-fmt clippy
 # Rust all tests
 test: unit-test doctest
 
+# Run all code-quality checks
+precommit: test lints
+
 # Publish crate to crates.io
 publish:
   cargo publish --token $CARGO_REGISTRY_TOKEN
@@ -51,3 +54,6 @@ audit:
 # Check GitHub Actions security analysis with `zizmor`
 check-github-actions-security:
   zizmor .
+
+# Performs one-time repo setup
+setup: git config core.hooksPath .githooks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,3 +80,5 @@ you can run the basic CI checks in your local environment:
   modern test runner for Rust.
 - [`cargo-audit`](https://docs.rs/cargo-audit/latest/cargo_audit/):
   tool to check `Cargo.lock` files for security vulnerabilities.
+
+Please do `git config core.hooksPath .githooks` to automatically run these tools on each commit.


### PR DESCRIPTION
## Description

These can be be enabled by running `git config core.hooksPath .githooks`. We don't want icky commits.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

- Right now the hook duplicates the code-quality commands. We could invoke `just test` and `just lint` instead, at the cost of requiring `just` to be installed.
- Should the command be `just precommit` or `just pre-commit`? 

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
